### PR TITLE
Inclusion of new NAMED_COLORS

### DIFF
--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -277,7 +277,9 @@ class CSSToExcelConverter(object):
 
     NAMED_COLORS = {
         'maroon': '800000',
+        'brown': 'A52A2A',
         'red': 'FF0000',
+        'pink': 'FFC0CB',
         'orange': 'FFA500',
         'yellow': 'FFFF00',
         'olive': '808000',
@@ -291,6 +293,7 @@ class CSSToExcelConverter(object):
         'navy': '000080',
         'black': '000000',
         'gray': '808080',
+        'grey': '808080',
         'silver': 'C0C0C0',
         'white': 'FFFFFF',
     }


### PR DESCRIPTION
included 'brown' (#A52A2A), 'pink' ('FFC0CB') and 'grey', US-standard spelling of the word 'gray'

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
